### PR TITLE
Allow lookup of Delay Line from BlockDSPSystem

### DIFF
--- a/BlockDSP/bdsp_system.cpp
+++ b/BlockDSP/bdsp_system.cpp
@@ -38,8 +38,8 @@ BlockDSPSystem::~BlockDSPSystem() {
         delete num;
     }
     
-    for (size_t i=0; i<_pimpl->delayLines.size(); i++) {
-        delete _pimpl->delayLines[i];
+    for (auto it = _pimpl->delayLineMap.begin(); it != _pimpl->delayLineMap.end(); it++) {
+        delete it->second;
     }
     
     delete _pimpl;
@@ -60,13 +60,12 @@ void BlockDSPSystem::removeNode(BlockDSPNode *node) {
 
 void BlockDSPSystem::addDelayLine(BlockDSPDelayLine *dl) {
     dl->id = _pimpl->counter++;
-    _pimpl->delayLines.push_back(dl);
+    _pimpl->delayLineMap[dl->id] = dl;
 }
 
 void BlockDSPSystem::next() {
-    for (size_t i=0; i<_pimpl->delayLines.size(); i++) {
-        BlockDSPDelayLine *dl = _pimpl->delayLines[i];
-        dl->shuffle();
+    for (auto it = _pimpl->delayLineMap.begin(); it != _pimpl->delayLineMap.end(); it++) {
+        it->second->shuffle();
     }
 }
 
@@ -147,6 +146,15 @@ BlockDSPNumber * BlockDSPSystem::numberWithName(const char *name) {
     return nullptr;
 }
 
+BlockDSPDelayLine * BlockDSPSystem::delayLineWithID(BlockDSPNodeID id) {
+    auto it = _pimpl->delayLineMap.find(id);
+    if (it != _pimpl->delayLineMap.end()) {
+        return it->second;
+    } else {
+        return NULL;
+    }
+}
+
 BlockDSPSystem *BlockDSPSystem::systemForBiQuad(uint32_t numChannels, unsigned int sampleRate) {
     BlockDSPSystem *system = new BlockDSPSystem(numChannels);
     BlockDSPDelayLine *inDelayLine = system->createDelayLine(system->mainInputNode);
@@ -199,8 +207,8 @@ BlockDSPSystem *BlockDSPSystem::systemForBiQuad(uint32_t numChannels, unsigned i
 }
 
 void BlockDSPSystem::reset() {
-    for (size_t i=0; i<_pimpl->delayLines.size(); i++) {
-        _pimpl->delayLines[i]->reset();
+    for (auto it = _pimpl->delayLineMap.begin(); it != _pimpl->delayLineMap.end(); it++) {
+        it->second->reset();
     }
     
     memset(mainInputNode->inputBuffer, 0, sizeof(float) * _pimpl->numChannels);

--- a/BlockDSP/bdsp_system.hpp
+++ b/BlockDSP/bdsp_system.hpp
@@ -52,8 +52,13 @@ public:
     BlockDSPNode *nodeWithID(BlockDSPNodeID id);
     /** Get the number with the given name
       * @param name the name of the number
+      * @returns the number or NULL if not found
       */
     BlockDSPNumber *numberWithName(const char *name);
+    /** Get the delay line with the given ID
+      * @returns the delay line or NULL if not found
+      */
+    BlockDSPDelayLine *delayLineWithID(BlockDSPNodeID id);
     /** Create a new delay line and add it to the system 
       * @param inputNode the input to the delay line
       */

--- a/BlockDSP/bdsp_system_private.hpp
+++ b/BlockDSP/bdsp_system_private.hpp
@@ -19,7 +19,7 @@ class BlockDSPSystem::pimpl
 {
 public:
     std::unordered_map<BlockDSPNodeID, BlockDSPNode *> nodeMap;
-    std::vector<BlockDSPDelayLine *>delayLines;
+    std::unordered_map<BlockDSPNodeID, BlockDSPDelayLine *> delayLineMap;
     std::unordered_map<std::string, BlockDSPParameter *> parameterMap;
     std::unordered_map<std::string, BlockDSPNumber *> numberMap;
     


### PR DESCRIPTION
* Use unordered_map to store delay lines in BlockDSPSystem
* Add delayLineWithID() method