### PR TITLE
Refactor to allow parameters to call back to APU

### DIFF
--- a/BlockDSP/bdsp_apu.cpp
+++ b/BlockDSP/bdsp_apu.cpp
@@ -31,3 +31,7 @@ void BlockDSPAPU::setMaxOutputChannels(uint32_t num)
 {
     system->setNumOutputChannels(num);
 }
+
+void BlockDSPAPU::onParameterChanged(BlockDSPParameter *parameter, BlockDSPNumber *value)
+{
+}

--- a/BlockDSP/bdsp_apu.hpp
+++ b/BlockDSP/bdsp_apu.hpp
@@ -13,6 +13,8 @@
 #include "autil_audioprocessingunit.hpp"
 #include "bdsp_system.hpp"
 
+class BlockDSPParameter;
+
 /** An AudioProcessingUnit built with a BlockDSP system */
 class BlockDSPAPU : public AudioProcessingUnit
 {
@@ -22,8 +24,16 @@ public:
     /** Process a frame of audio. See AudioProcessingUnit */
     virtual void processAudio(float *inputBuffer, float *outputBuffer, int numInputChannels, int numOutputChannels);
     
+    /** Set max number of input channels */
     virtual void setMaxInputChannels(uint32_t num);
+    /** Set max number of output channels */
     virtual void setMaxOutputChannels(uint32_t num);
+    
+    /** Called when a BlockDSPParameter's value is changed
+      * @param parameter the BlockDSPParameter instance whose value was modified
+      * @param value a number representing the new value. *NOTE* do not keep a reference to this value; its memory will be freed after the callback returns.
+      */
+    virtual void onParameterChanged(BlockDSPParameter *parameter, BlockDSPNumber *value);
 };
 
 

--- a/BlockDSP/bdsp_parameter.cpp
+++ b/BlockDSP/bdsp_parameter.cpp
@@ -11,14 +11,14 @@
 #include "bdsp_number.hpp"
 #include <string.h>
 
-BlockDSPParameter::BlockDSPParameter(BlockDSPNumberType type, const char *name, BlockDSPNumber *target, BlockDSPSystem *system)
+BlockDSPParameter::BlockDSPParameter(BlockDSPNumberType type, const char *name, BlockDSPNumber *target, BlockDSPAPU *contextAPU)
 {
     _pimpl = new pimpl;
     _pimpl->type = type;
     setTarget(target);
     setName(name);
     callback = 0;
-    _pimpl->system = system;
+    _pimpl->contextAPU = contextAPU;
 }
 
 BlockDSPParameter::~BlockDSPParameter()
@@ -49,8 +49,13 @@ bool BlockDSPParameter::setValue(float val)
     if (_pimpl->target)
         _pimpl->target->setFloatValue(val);
     
-    if (callback)
-        (*callback)(_pimpl->system, this, &val);
+    BlockDSPNumber *num = BlockDSPNumber::numberForFloat(val);
+    
+    if (callback) {
+        (*callback)(_pimpl->contextAPU, this, num);
+    }
+    _pimpl->contextAPU->onParameterChanged(this, num);
+    delete num;
     
     return true;
     
@@ -64,8 +69,14 @@ bool BlockDSPParameter::setValue(bool b)
     if (_pimpl->target)
         _pimpl->target->setBoolValue(b);
     
-    if (callback)
-        (*callback)(_pimpl->system, this, &b);
+    BlockDSPNumber *num = BlockDSPNumber::numberForBool(b);
+    
+    if (callback) {
+        (*callback)(_pimpl->contextAPU, this, num);
+    }
+    
+    _pimpl->contextAPU->onParameterChanged(this, num);
+    delete num;
     
     return true;
 }
@@ -78,8 +89,13 @@ bool BlockDSPParameter::setValue(int val)
     if (_pimpl->target)
         _pimpl->target->setIntegerValue(val);
     
-    if (callback)
-        (*callback)(_pimpl->system, this, &val);
+    BlockDSPNumber *num = BlockDSPNumber::numberForInteger(val);
+    
+    if (callback) {
+        (*callback)(_pimpl->contextAPU, this, num);
+    }
+    _pimpl->contextAPU->onParameterChanged(this, num);
+    delete num;
     
     return true;
 }

--- a/BlockDSP/bdsp_parameter.hpp
+++ b/BlockDSP/bdsp_parameter.hpp
@@ -11,14 +11,14 @@
 #define BlockDSPParameter_hpp
 
 #include "bdsp_number.hpp"
+#include "bdsp_apu.hpp"
 
 #define BDSP_MAX_PARAMLEN 256
 
-class BlockDSPSystem;
 class BlockDSPParameter;
 
-/** typedef for callback function pointer for parameters. The callback is an optional function that will be called when the parameter changes. The parameters are the BlockDSPSystem instance, a pointer to the parameter that changed, and a pointer to the new value of the parameter. Use the *type()* method of the parameter to get the type to which to cast the value pointer */
-typedef void (* BlockDSPParameterCallback)(BlockDSPSystem *, BlockDSPParameter *, void *value);
+/** typedef for callback function pointer for parameters. The callback is an optional function that will be called when the parameter changes. The parameters are the BlockDSPAPU instance, a pointer to the parameter that changed, and a pointer to a BlockDSPNumber instance representing the new value. *NOTE* the BlockDSPNumber instance is only guaranteed to be valid for the lifespan of the callback. *DO NOT* keep a reference to this value */
+typedef void (* BlockDSPParameterCallback)(BlockDSPAPU *, BlockDSPParameter *, BlockDSPNumber *value);
 
 /** A parameter that can be used to change a number and/or trigger a callback */
 class BlockDSPParameter {
@@ -29,7 +29,7 @@ public:
       * @param target a pointer to the number to change when the parameter is modified. Can be NULL
       * @param system the containing system 
       */
-    BlockDSPParameter(BlockDSPNumberType type, const char *name, BlockDSPNumber *target, BlockDSPSystem *system);
+    BlockDSPParameter(BlockDSPNumberType type, const char *name, BlockDSPNumber *target, BlockDSPAPU *contextAPU);
     ~BlockDSPParameter();
     /** Set the name of the parameter */
     void setName(const char *name);

--- a/BlockDSP/bdsp_parameter_private.hpp
+++ b/BlockDSP/bdsp_parameter_private.hpp
@@ -19,7 +19,7 @@ public:
     char name[BDSP_MAX_PARAMLEN];
     BlockDSPNumber *target;
     BlockDSPNumberType type;
-    BlockDSPSystem *system;
+    BlockDSPAPU *contextAPU;
 };
 
 

--- a/BlockDSP/bdsp_system.cpp
+++ b/BlockDSP/bdsp_system.cpp
@@ -8,6 +8,7 @@
 
 #include "bdsp_system.hpp"
 #include "bdsp_system_private.hpp"
+#include "bdsp_parameter.hpp"
 #include "dsphelpers.hpp"
 #include "bdsp_number.hpp"
 
@@ -125,9 +126,9 @@ void BlockDSPSystem::addParameter(BlockDSPParameter *param) {
     _pimpl->parameterMap[param->name()] = param;
 }
 
-BlockDSPParameter * BlockDSPSystem::createParameter(const char *name, BlockDSPNumberType type, BlockDSPNumber *target)
+BlockDSPParameter * BlockDSPSystem::createParameter(const char *name, BlockDSPNumberType type, BlockDSPNumber *target, BlockDSPAPU *contextAPU)
 {
-    BlockDSPParameter *param = new BlockDSPParameter(type, name, target, this);
+    BlockDSPParameter *param = new BlockDSPParameter(type, name, target, contextAPU);
     addParameter(param);
     
     return param;
@@ -211,19 +212,12 @@ BlockDSPSystem *BlockDSPSystem::systemForBiQuad(uint32_t numChannels, unsigned i
     
     BiQuadCoefficients coeffs;
     coeffs.calculateForLPF(1000, 3.0, sampleRate);
-
     
     a0Node->coefficient = BlockDSPNumber::numberForFloat(coeffs.a0);
     a1Node->coefficient = BlockDSPNumber::numberForFloat(coeffs.a1);
     a2Node->coefficient = BlockDSPNumber::numberForFloat(coeffs.a2);
     b1Node->coefficient = BlockDSPNumber::numberForFloat(-1 * coeffs.b1);
     b2Node->coefficient = BlockDSPNumber::numberForFloat(-1 * coeffs.b2);
-    
-    system->createParameter("a0", BlockDSPNumberType::FLOAT, a0Node->coefficient);
-    system->createParameter("a1", BlockDSPNumberType::FLOAT, a1Node->coefficient);
-    system->createParameter("a2", BlockDSPNumberType::FLOAT, a2Node->coefficient);
-    system->createParameter("b1", BlockDSPNumberType::FLOAT, b1Node->coefficient);
-    system->createParameter("b2", BlockDSPNumberType::FLOAT, b2Node->coefficient);
     
     system->mainOutputNode = outGainNode;
     outGainNode->coefficient = BlockDSPNumber::numberForFloat(2.0);

--- a/BlockDSP/bdsp_system.hpp
+++ b/BlockDSP/bdsp_system.hpp
@@ -11,8 +11,10 @@
 #define BlockDSPSystem_hpp
 
 #include "bdsp_node.hpp"
-#include "bdsp_parameter.hpp"
 #include "bdsp_number.hpp"
+
+class BlockDSPParameter;
+class BlockDSPAPU;
 
 /** The container for all the objects associated with the audio processing chain */
 class BlockDSPSystem {
@@ -83,8 +85,9 @@ public:
       * @param name the name of the parameter
       * @param type the value type
       * @param target optional target number for the parameter. See the documentation for BlockDSPParameter
+      * @param contextAPU the Audio Processing Unit that the parameter will call back to
       */
-    BlockDSPParameter *createParameter(const char *name, BlockDSPNumberType type, BlockDSPNumber *target);
+    BlockDSPParameter *createParameter(const char *name, BlockDSPNumberType type, BlockDSPNumber *target, BlockDSPAPU *contextAPU);
     
     BlockDSPSystem();
     ~BlockDSPSystem();

--- a/Code Generation/bdsp_codebuilder.cpp
+++ b/Code Generation/bdsp_codebuilder.cpp
@@ -127,7 +127,7 @@ void BDCodeBuilder::writeHeaderFile()
     
     fprintf(f, "\n//This file was automatically generated.\n\n#ifndef BlockDSP_Factory_HPP\n#define BlockDSP_Factory_HPP\n");
     fprintf(f, "\n#include <blockdsp.h>");
-    fprintf(f, "\nextern \"C\" BlockDSPSystem * BlockDSPFactoryCreateSystem();\n");
+    fprintf(f, "\nextern \"C\" BlockDSPSystem * BlockDSPFactoryCreateSystem(BlockDSPAPU *apu);\n");
     fprintf(f, "\nextern \"C\" AudioProcessingUnit *AudioProcessingUnitFactoryCreate();\n");
     fprintf(f, "\n#endif\n");
     
@@ -164,7 +164,7 @@ void BDCodeBuilder::openSourceFile()
     _pimpl->nodeSet["MAIN_INPUT_NODE"] = true;
     _pimpl->nodeSet["MAIN_OUTPUT_NODE"] = true;
     
-    fprintf(f, "\nBlockDSPSystem * BlockDSPFactoryCreateSystem() {\n");
+    fprintf(f, "\nBlockDSPSystem * BlockDSPFactoryCreateSystem(BlockDSPAPU *_CONTEXT_APU) {\n");
     fprintf(f, "BlockDSPSystem *system = new BlockDSPSystem();\n");
     fprintf(f, "BlockDSPInputNode *MAIN_INPUT_NODE = system->mainInputNode;\n");
     fprintf(f, "BlockDSPMultiplierNode *MAIN_OUTPUT_NODE = system->createMultiplierNode();\n");
@@ -183,7 +183,7 @@ void BDCodeBuilder::closeSourceFile()
     fprintf(_pimpl->openFile, "\nreturn system;\n");
     fprintf(_pimpl->openFile, "\n}\n");
     fprintf(_pimpl->openFile, "\n\nAudioProcessingUnit *AudioProcessingUnitFactoryCreate() {\n");
-    fprintf(_pimpl->openFile, "BlockDSPAPU *unit = new BlockDSPAPU();\nunit->system = BlockDSPFactoryCreateSystem();\nreturn unit;\n}\n");
+    fprintf(_pimpl->openFile, "BlockDSPAPU *unit = new BlockDSPAPU();\nunit->system = BlockDSPFactoryCreateSystem(unit);\nreturn unit;\n}\n");
     fclose(_pimpl->openFile);
     _pimpl->openFile = 0;
 }
@@ -266,7 +266,7 @@ void BDCodeBuilder::addParameter(const char *name, const char *callback, const c
             return;
     }
     
-    fprintf(_pimpl->openFile, "BlockDSPParameter *%s = system->createParameter(\"%s\", %s, %s);\n", name, name, typeParam, targetParam);
+    fprintf(_pimpl->openFile, "BlockDSPParameter *%s = system->createParameter(\"%s\", %s, %s, _CONTEXT_APU);\n", name, name, typeParam, targetParam);
     if (callback)
         fprintf(_pimpl->openFile, "%s->callback = %s;\n", name, callback);
 }

--- a/dsptest/main.cpp
+++ b/dsptest/main.cpp
@@ -81,8 +81,10 @@ int main(int argc, const char * argv[]) {
     write_test_system(built_code_path);
     
     AudioProcessingUnit *apunit = load_apu(dylib_path);
-    if (!apunit)
+    if (!apunit) {
         BDLog("[setup]", "FAILED to load APU");
+        abort();
+    }
     
     BDLog("[setup]", "Start");
     AudioManager audioManager;

--- a/test/gunit/test_bdsp_system.cpp
+++ b/test/gunit/test_bdsp_system.cpp
@@ -4,8 +4,11 @@
 class BDSPSystemTestFixture : public testing::Test {
 protected:
 	BlockDSPSystem * system;
+	BlockDSPAPU *contextAPU;
 	void SetUp() {
+		contextAPU = new BlockDSPAPU();
 		system = new BlockDSPSystem();
+		contextAPU->system = system;
 	}
 	void TearDown() {
 		delete system;
@@ -14,7 +17,7 @@ protected:
 
 TEST_F(BDSPSystemTestFixture, test_system_parameter)
 {
-	BlockDSPParameter *param = system->createParameter("param", BlockDSPNumberType::FLOAT, NULL);
+	BlockDSPParameter *param = system->createParameter("param", BlockDSPNumberType::FLOAT, NULL, contextAPU);
 	ASSERT_TRUE((param != NULL));
 	BlockDSPParameter *lookup = system->parameterWithName("param");
 	EXPECT_EQ(param, lookup);

--- a/test/gunit/test_parameter.cpp
+++ b/test/gunit/test_parameter.cpp
@@ -5,24 +5,27 @@ class ParameterTestFixture : public testing::Test
 {
 protected:
 	BlockDSPSystem *system;
+	BlockDSPAPU *contextAPU;
 
 	void SetUp() {
 		system = new BlockDSPSystem();
+		contextAPU = new BlockDSPAPU();
+		contextAPU->system = system;
 	}
 
 	void TearDown() {
 		delete system;
+		delete contextAPU;
 	}
 };
 
-void callback_fn1(BlockDSPSystem *system, 
+void callback_fn1(BlockDSPAPU *contextAPU, 
 				BlockDSPParameter *param, 
-				void *value)
+				BlockDSPNumber *value)
 {
-	float *floatPtr = (float *)value;
-	BlockDSPNumber *num = system->numberWithName("number");
+	BlockDSPNumber *num = contextAPU->system->numberWithName("number");
 	ASSERT_TRUE((num != nullptr));
-	num->setFloatValue(*floatPtr);
+	num->setFloatValue(value->floatValue());
 }
 
 TEST_F(ParameterTestFixture, test_target_number)
@@ -30,7 +33,7 @@ TEST_F(ParameterTestFixture, test_target_number)
 	BlockDSPNumber num;
 
 	num.setFloatValue(1);
-	BlockDSPParameter floatParam(BlockDSPNumberType::FLOAT, "floatParam", &num, system);
+	BlockDSPParameter floatParam(BlockDSPNumberType::FLOAT, "floatParam", &num, contextAPU);
 	floatParam.setValue(2.f);
 	EXPECT_EQ(2.f, num.floatValue());
 
@@ -38,12 +41,12 @@ TEST_F(ParameterTestFixture, test_target_number)
 	EXPECT_EQ(4.f, num.floatValue());
 
 	num.setIntegerValue(1);
-	BlockDSPParameter intParam(BlockDSPNumberType::INTEGER, "intParam", &num, system);
+	BlockDSPParameter intParam(BlockDSPNumberType::INTEGER, "intParam", &num, contextAPU);
 	intParam.setValue(3);
 	EXPECT_EQ(3, num.integerValue());
 
 	num.setBoolValue(false);
-	BlockDSPParameter boolParam(BlockDSPNumberType::BOOLEAN, "boolParam", &num, system);
+	BlockDSPParameter boolParam(BlockDSPNumberType::BOOLEAN, "boolParam", &num, contextAPU);
 	boolParam.setValue(true);
 	EXPECT_EQ(true, num.boolValue());
 }
@@ -54,7 +57,7 @@ TEST_F(ParameterTestFixture, test_callback)
 	number->setFloatValue(0);
 	system->addNumber("number", number);
 
-	BlockDSPParameter *param = system->createParameter("param", BlockDSPNumberType::FLOAT, NULL);
+	BlockDSPParameter *param = system->createParameter("param", BlockDSPNumberType::FLOAT, NULL, contextAPU);
 	param->callback = callback_fn1;
 	param->setValue(3.f);
 
@@ -70,7 +73,7 @@ TEST_F(ParameterTestFixture, test_callback_and_param)
 
 	system->addNumber("number", number);
 
-	BlockDSPParameter *param = system->createParameter("param", BlockDSPNumberType::FLOAT, number2);
+	BlockDSPParameter *param = system->createParameter("param", BlockDSPNumberType::FLOAT, number2, contextAPU);
 	param->callback = callback_fn1;
 
 	param->setValue(3.f);


### PR DESCRIPTION
Refactor to make all BlockDSPParameters automatically call back to their associated BlockDSPAPU instance. Parameters will always trigger `onParameterChanged()` when the value is changed. There is still the option to add an additional callback using the `callback` member.

For later:
BlockDSPSystem has no need to know about parameters. The BlockDSPAPU instance should maintain and create parameters instead.