### PR TITLE
Is71 reference count

### DIFF
--- a/Audio Manager/autil_number.cpp
+++ b/Audio Manager/autil_number.cpp
@@ -19,7 +19,7 @@ APUNumber::APUNumber()
 
 APUNumber::APUNumber(const APUNumber& num)
 {
-    _pimpl = num._pimpl;
+    _pimpl = num._pimpl->copy();
 }
 
 APUNumber::APUNumber(std::shared_ptr<pimpl> impl)

--- a/test/gunit/test_apunumber.cpp
+++ b/test/gunit/test_apunumber.cpp
@@ -36,14 +36,6 @@ TEST_F(TestAPUNumber, test_number_types)
 	EXPECT_EQ(false, boolNumber.boolValue());
 }
 
-TEST_F(TestAPUNumber, test_copy_constructor)
-{
-	APUNumber num;
-	APUNumber num2(num);
-
-	num.setFloatValue(3.5);
-	EXPECT_EQ(3.5, num2.floatValue());
-}
 
 TEST_F(TestAPUNumber, test_assignment)
 {


### PR DESCRIPTION
Changed the APUNumber constructor to create a copy instead of referencing original.